### PR TITLE
chore: add automatic cloud deployment to Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,3 +603,53 @@ npm run build
 ```
 
 All four commands must exit with code 0 for CI to pass.
+
+---
+
+## 10. Cloud Deployment (CD)
+
+The application is deployed on [Render](https://render.com) and redeployed automatically whenever changes are merged into `main`.
+
+### Live URLs
+
+| Service  | URL                      |
+| -------- | ------------------------ |
+| Frontend | _add after first deploy_ |
+| Backend  | _add after first deploy_ |
+
+### How it works
+
+```
+merge to main
+    → Render detects new commit on main
+    → backend service redeploys (pip install + uvicorn)
+    → frontend static site rebuilds (npm ci + vite build)
+```
+
+No GitHub Actions step is needed for deployment — Render pulls directly from the linked GitHub repo.
+
+### Infrastructure as Code
+
+Deployment is defined in `render.yaml` at the repo root. It declares:
+
+- **`mpi-db`** — managed PostgreSQL (free tier); `DATABASE_URL` is injected automatically into the backend
+- **`mpi-backend`** — Python web service; runs `uvicorn main:app`
+- **`mpi-frontend`** — static site; runs `npm ci && npm run build`, serves `dist/`
+
+### First-time setup on Render
+
+1. Go to [render.com](https://render.com) → **New → Blueprint** → connect your GitHub repo
+2. Render reads `render.yaml` and creates all three resources automatically
+3. After the backend is deployed, copy its public URL and set these env vars in the Render dashboard:
+   - **Backend** → `ALLOWED_ORIGINS` = `https://your-frontend.onrender.com`
+   - **Frontend** → `VITE_API_URL` = `https://your-backend.onrender.com`
+4. Trigger a manual redeploy of both services for the env vars to take effect
+5. Update the Live URLs table above with the final public URLs
+
+### Environment variables in production
+
+| Service  | Variable          | Where to set     | Value                             |
+| -------- | ----------------- | ---------------- | --------------------------------- |
+| Backend  | `DATABASE_URL`    | Auto-injected    | Render Postgres connection string |
+| Backend  | `ALLOWED_ORIGINS` | Render dashboard | Frontend public URL               |
+| Frontend | `VITE_API_URL`    | Render dashboard | Backend public URL                |

--- a/README.md
+++ b/README.md
@@ -612,10 +612,10 @@ The application is deployed on [Render](https://render.com) and redeployed autom
 
 ### Live URLs
 
-| Service  | URL                      |
-| -------- | ------------------------ |
-| Frontend | _add after first deploy_ |
-| Backend  | _add after first deploy_ |
+| Service  | URL                               |
+| -------- | --------------------------------- |
+| Frontend | https://mpi-frontend.onrender.com |
+| Backend  | https://mpi-backend.onrender.com  |
 
 ### How it works
 

--- a/README.md
+++ b/README.md
@@ -640,9 +640,9 @@ Deployment is defined in `render.yaml` at the repo root. It declares:
 
 1. Go to [render.com](https://render.com) → **New → Blueprint** → connect your GitHub repo
 2. Render reads `render.yaml` and creates all three resources automatically
-3. After the backend is deployed, copy its public URL and set these env vars in the Render dashboard:
-   - **Backend** → `ALLOWED_ORIGINS` = `https://your-frontend.onrender.com`
-   - **Frontend** → `VITE_API_URL` = `https://your-backend.onrender.com`
+3. After the backend and frontend are deployed, copy both public URLs and set these env vars in the Render dashboard:
+   - **Backend** → `ALLOWED_ORIGINS` = `https://your-frontend.onrender.com` (use the **frontend** public URL here)
+   - **Frontend** → `VITE_API_URL` = `https://your-backend.onrender.com` (use the **backend** public URL here)
 4. Trigger a manual redeploy of both services for the env vars to take effect
 5. Update the Live URLs table above with the final public URLs
 

--- a/README.md
+++ b/README.md
@@ -639,17 +639,17 @@ Deployment is defined in `render.yaml` at the repo root. It declares:
 ### First-time setup on Render
 
 1. Go to [render.com](https://render.com) → **New → Blueprint** → connect your GitHub repo
-2. Render reads `render.yaml` and creates all three resources automatically
-3. After the backend and frontend are deployed, copy both public URLs and set these env vars in the Render dashboard:
+2. Render reads `render.yaml` and creates all three resources automatically — `ALLOWED_ORIGINS` and `VITE_API_URL` are pre-configured with the default service URLs
+3. Only update these env vars in the Render dashboard if you use custom domains or different service names:
    - **Backend** → `ALLOWED_ORIGINS` = `https://your-frontend.onrender.com` (use the **frontend** public URL here)
    - **Frontend** → `VITE_API_URL` = `https://your-backend.onrender.com` (use the **backend** public URL here)
-4. Trigger a manual redeploy of both services for the env vars to take effect
+4. If you changed either env var in the dashboard, trigger a manual redeploy of the affected service for the new value to take effect
 5. Update the Live URLs table above with the final public URLs
 
 ### Environment variables in production
 
-| Service  | Variable          | Where to set     | Value                             |
-| -------- | ----------------- | ---------------- | --------------------------------- |
-| Backend  | `DATABASE_URL`    | Auto-injected    | Render Postgres connection string |
-| Backend  | `ALLOWED_ORIGINS` | Render dashboard | Frontend public URL               |
-| Frontend | `VITE_API_URL`    | Render dashboard | Backend public URL                |
+| Service  | Variable          | Where to set                                             | Value                             |
+| -------- | ----------------- | -------------------------------------------------------- | --------------------------------- |
+| Backend  | `DATABASE_URL`    | Auto-injected                                            | Render Postgres connection string |
+| Backend  | `ALLOWED_ORIGINS` | `render.yaml` by default; dashboard only when overriding | Frontend public URL               |
+| Frontend | `VITE_API_URL`    | `render.yaml` by default; dashboard only when overriding | Backend public URL                |

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,10 +16,13 @@ app = FastAPI(
     version="1.0.0",
 )
 
+_allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
 _allowed_origins = [
     o.strip()
-    for o in os.getenv(
-        "ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
+    for o in (
+        _allowed_origins_env
+        if _allowed_origins_env and _allowed_origins_env.strip()
+        else "http://localhost:5173,http://127.0.0.1:5173"
     ).split(",")
     if o.strip()
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Generator
 
 import models
@@ -15,12 +16,14 @@ app = FastAPI(
     version="1.0.0",
 )
 
+_raw_origins = os.getenv(
+    "ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
+)
+_allowed_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-    ],
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,10 +16,13 @@ app = FastAPI(
     version="1.0.0",
 )
 
-_raw_origins = os.getenv(
-    "ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
-)
-_allowed_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
+_allowed_origins = [
+    o.strip()
+    for o in os.getenv(
+        "ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
+    ).split(",")
+    if o.strip()
+]
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,14 +17,13 @@ app = FastAPI(
 )
 
 _allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
+_allowed_origins_raw = (
+    _allowed_origins_env
+    if _allowed_origins_env and _allowed_origins_env.strip()
+    else "http://localhost:5173,http://127.0.0.1:5173"
+)
 _allowed_origins = [
-    o.strip()
-    for o in (
-        _allowed_origins_env
-        if _allowed_origins_env and _allowed_origins_env.strip()
-        else "http://localhost:5173,http://127.0.0.1:5173"
-    ).split(",")
-    if o.strip()
+    o.strip() for o in _allowed_origins_raw.split(",") if o.strip() and o.strip() != "*"
 ]
 
 app.add_middleware(

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+databases:
+  - name: mpi-db
+    databaseName: mpi_db
+    user: mpi_user
+    plan: free
+
+services:
+  - type: web
+    name: mpi-backend
+    runtime: python
+    plan: free
+    rootDir: backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: mpi-db
+          property: connectionString
+      - key: ALLOWED_ORIGINS
+        sync: false # set manually in Render dashboard after frontend is deployed
+
+  - type: static
+    name: mpi-frontend
+    rootDir: frontend
+    buildCommand: npm ci && npm run build
+    staticPublishPath: dist
+    envVars:
+      - key: VITE_API_URL
+        sync: false # set manually in Render dashboard after backend is deployed

--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,7 @@ services:
           name: mpi-db
           property: connectionString
       - key: ALLOWED_ORIGINS
-        sync: false # set manually in Render dashboard after frontend is deployed
+        value: https://mpi-frontend.onrender.com
 
   - type: web
     name: mpi-frontend
@@ -28,4 +28,4 @@ services:
     staticPublishPath: dist
     envVars:
       - key: VITE_API_URL
-        sync: false # set manually in Render dashboard after backend is deployed
+        value: https://mpi-backend.onrender.com

--- a/render.yaml
+++ b/render.yaml
@@ -20,8 +20,9 @@ services:
       - key: ALLOWED_ORIGINS
         sync: false # set manually in Render dashboard after frontend is deployed
 
-  - type: static
+  - type: web
     name: mpi-frontend
+    runtime: static
     rootDir: frontend
     buildCommand: npm ci && npm run build
     staticPublishPath: dist


### PR DESCRIPTION
DESCRIPTION:
## Summary
Sets up Continuous Deployment (CD) so that the backend and frontend are automatically redeployed to Render after changes are merged into `main`. Closes #27 

## Changes
- `render.yaml` — Infrastructure as Code for Render Blueprint; declares managed PostgreSQL, backend web service, and frontend static site
- `backend/main.py` — CORS allowed origins now read from `ALLOWED_ORIGINS` env var (comma-separated) with localhost fallback for local dev
- `README.md` — added Section 10 with live URLs, deployment architecture, first-time Render setup guide, and production env vars reference

## Live URLs
| Service  | URL |
| -------- | --- |
| Frontend | https://mpi-frontend.onrender.com |
| Backend  | https://mpi-backend.onrender.com |

## How deployment works
```
merge to main
    → Render detects new commit
    → backend redeploys (pip install + uvicorn)
    → frontend rebuilds (npm ci + vite build)
```
No additional GitHub Actions step needed — Render pulls directly from GitHub.

## Production environment variables set on Render
| Service  | Variable          | Value                                     |
| -------- | ----------------- | ----------------------------------------- |
| Backend  | DATABASE_URL      | Auto-injected from Render Postgres        |
| Backend  | ALLOWED_ORIGINS   | https://mpi-frontend.onrender.com         |
| Frontend | VITE_API_URL      | https://mpi-backend.onrender.com          |

## Testing
- Frontend loads at https://mpi-frontend.onrender.com
- Users page fetches live data from backend
- End-to-end flow verified working in production


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Cloud Deployment guide with live service URLs, automatic redeploy flow on Render, setup steps, and production environment variables.

* **Chores**
  * Added infrastructure-as-code for Render: managed database, backend service, and static frontend with environment-variable wiring.
  * Made allowed CORS origins configurable via an environment variable for runtime adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->