### PR TITLE
feat: implement end-to-end leave management core logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ ALTER DATABASE mpi_db OWNER TO postgres;
 \q
 ```
 
+### Step 2.1: Database Reset & Seeding
+
+Whenever the database schema changes (e.g., new columns or tables are added), or if you simply want to start fresh with clean data, you can run the database reset script.
+
+This script will drop all existing tables, recreate them to match the latest `models.py`, and populate the database with mock users.
+
+Ensure your backend virtual environment is active and run:
+```bash
+cd backend
+python reset_db.py
+```
+
+Note: This will permanently delete all existing data in your local database.
+
 ### Step 3: Backend Setup & Running the Server
 
 Once your database is up and running, open a new terminal window and follow these OS-specific steps to start the API.

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-# Load .env from repo root (works for both native and Docker runs)
 load_dotenv(dotenv_path=Path(__file__).resolve().parent.parent / ".env")
 
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ import models
 from database import SessionLocal, engine
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import users
+from routers import leave, users
 from sqlalchemy.orm import Session
 
 models.Base.metadata.create_all(bind=engine)
@@ -45,3 +45,4 @@ def get_db() -> Generator[Session, None, None]:
 
 
 app.include_router(users.router)
+app.include_router(leave.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,21 +1,29 @@
 import enum
+from datetime import date, datetime, timezone
 
 from database import Base
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.orm import relationship
 
 
 class RoleEnum(str, enum.Enum):
-    """Allowed role values for a user."""
+    """Enumeration of user roles within the application."""
 
     user = "User"
     manager = "Manager"
 
 
-class User(Base):
-    """Database model for users.
+class LeaveStatusEnum(str, enum.Enum):
+    """Enumeration of possible statuses for a leave request."""
 
-    Maps directly the Python class structure to the PostgreSQL table.
-    """
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class User(Base):
+    """Database model representing an employee/user in the system."""
 
     __tablename__ = "users"
 
@@ -24,3 +32,22 @@ class User(Base):
     role = Column(String, nullable=False, default=RoleEnum.user.value)
     position = Column(String, nullable=False)
     seniority = Column(String, nullable=False)
+    hire_date = Column(Date, nullable=False, default=date.today)
+
+    leave_requests = relationship("LeaveRequest", back_populates="user")
+
+
+class LeaveRequest(Base):
+    """Database model representing a leave request submitted by a user."""
+
+    __tablename__ = "leave_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    days_requested = Column(Integer, nullable=False)
+    status = Column(SQLEnum(LeaveStatusEnum), default=LeaveStatusEnum.PENDING)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    user = relationship("User", back_populates="leave_requests")

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,0 +1,45 @@
+from datetime import date
+
+import models
+from database import SessionLocal, engine
+
+
+def reset_and_seed() -> None:
+    """Drops all tables, recreates them, and seeds initial mock data."""
+    print("🗑️  Dropping all existing tables...")
+    models.Base.metadata.drop_all(bind=engine)
+
+    print("🏗️  Creating new tables based on current models...")
+    models.Base.metadata.create_all(bind=engine)
+
+    print("🌱 Seeding mock users...")
+    db = SessionLocal()
+    try:
+        mock_users = [
+            models.User(
+                name="Ion Popescu",
+                role=models.RoleEnum.user.value,
+                position="Backend Developer",
+                seniority="Mid",
+                hire_date=date(2022, 1, 15),  # Angajat in 2022
+            ),
+            models.User(
+                name="Maria Ionescu",
+                role=models.RoleEnum.manager.value,
+                position="Engineering Manager",
+                seniority="Senior",
+                hire_date=date(2020, 5, 10),  # Angajata in 2020
+            ),
+        ]
+        db.add_all(mock_users)
+        db.commit()
+        print("✅ Database reset and seeded successfully!")
+    except Exception as e:
+        print(f"❌ An error occurred during seeding: {e}")
+        db.rollback()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    reset_and_seed()

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -1,0 +1,133 @@
+from collections.abc import Generator
+from datetime import date, datetime, timezone
+
+import models
+import schemas
+from database import SessionLocal
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/leave", tags=["Leave Management"])
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Dependency to provide a database session.
+
+    Yields:
+        Session: A SQLAlchemy database session.
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def calculate_available_days(hire_date: date, used_days: int) -> float:
+    """Calculate the available leave days based on months worked.
+
+    Rule: 1.5 leave days per month worked.
+
+    Args:
+        hire_date: The date the employee was hired.
+        used_days: The number of days already approved or pending.
+
+    Returns:
+        The remaining leave balance.
+    """
+    today = datetime.now(timezone.utc).date()
+    months_worked = (today.year - hire_date.year) * 12 + (today.month - hire_date.month)
+    total_earned = max(0, months_worked * 1.5)
+    return float(total_earned - used_days)
+
+
+@router.post(
+    "/request",
+    response_model=schemas.LeaveRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_leave_request(
+    request: schemas.LeaveRequestCreate, db: Session = Depends(get_db)
+) -> models.LeaveRequest:
+    """Create a new leave request for a user.
+
+    Validates if the user exists and has enough leave balance.
+
+    Args:
+        request: The leave request payload containing dates.
+        db: The database session.
+
+    Returns:
+        The created leave request record.
+
+    Raises:
+        HTTPException: If user is not found or balance is insufficient.
+    """
+    user = db.query(models.User).filter(models.User.id == request.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    days_requested = (request.end_date - request.start_date).days + 1
+
+    approved_or_pending = (
+        db.query(models.LeaveRequest)
+        .filter(
+            models.LeaveRequest.user_id == user.id,
+            models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
+        )
+        .all()
+    )
+    used_days = sum(req.days_requested for req in approved_or_pending)
+
+    available_days = calculate_available_days(user.hire_date, used_days)
+    if days_requested > available_days:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Not enough leave days. Requested: {days_requested}, Available: {available_days}",
+        )
+
+    new_request = models.LeaveRequest(
+        user_id=request.user_id,
+        start_date=request.start_date,
+        end_date=request.end_date,
+        days_requested=days_requested,
+        status=models.LeaveStatusEnum.PENDING,
+    )
+
+    db.add(new_request)
+    db.commit()
+    db.refresh(new_request)
+
+    return new_request
+
+
+@router.get("/my-requests/{user_id}", response_model=list[schemas.LeaveRequestResponse])
+def get_user_leave_requests(
+    user_id: int, db: Session = Depends(get_db)
+) -> list[models.LeaveRequest]:
+    """Retrieve all leave requests for a specific user.
+
+    Args:
+        user_id: The ID of the user.
+        db: The database session.
+
+    Returns:
+        A list of leave requests ordered chronologically (newest first).
+
+    Raises:
+        HTTPException: If no requests are found.
+    """
+    requests = (
+        db.query(models.LeaveRequest)
+        .filter(models.LeaveRequest.user_id == user_id)
+        .order_by(desc(models.LeaveRequest.created_at))
+        .all()
+    )
+
+    if not requests:
+        raise HTTPException(
+            status_code=404, detail="No leave requests found for this user"
+        )
+
+    return requests

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,13 +1,60 @@
-from pydantic import BaseModel, ConfigDict
+from datetime import date, datetime
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class LeaveStatus(str, Enum):
+    """Enumeration of possible statuses for a leave request payload."""
+
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class LeaveRequestCreate(BaseModel):
+    """Schema for creating a new leave request."""
+
+    user_id: int
+    start_date: date
+    end_date: date
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> "LeaveRequestCreate":
+        """Ensure end_date is after or equal to start_date.
+
+        Returns:
+            The validated model.
+
+        Raises:
+            ValueError: If end_date is before start_date.
+        """
+        if self.end_date < self.start_date:
+            raise ValueError("end_date must be strictly after or equal to start_date")
+        return self
+
+
+class LeaveRequestResponse(BaseModel):
+    """Schema for returning a leave request to the client."""
+
+    id: int
+    user_id: int
+    start_date: date
+    end_date: date
+    days_requested: int
+    status: LeaveStatus
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserResponse(BaseModel):
-    """Pydantic schema for serialising a user in API responses."""
-
-    model_config = ConfigDict(from_attributes=True)
+    """Schema for returning user data to the client."""
 
     id: int
     name: str
     role: str
     position: str
     seniority: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -92,7 +92,9 @@ def test_schema_generation_leave_requests_table(db_inspector: Inspector) -> None
         "created_at",
     ]
     for col_name in expected_columns:
-        assert col_name in columns, f"Column {col_name} is missing from 'leave_requests'"
+        assert col_name in columns, (
+            f"Column {col_name} is missing from 'leave_requests'"
+        )
 
     pk = db_inspector.get_pk_constraint("leave_requests")
     assert pk.get("constrained_columns") == ["id"], (

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -62,7 +62,7 @@ def test_schema_generation_users_table(db_inspector: Inspector) -> None:
     assert "users" in tables, "Table 'users' was not created by SQLAlchemy"
     # Check columns
     columns = {col["name"]: col for col in db_inspector.get_columns("users")}
-    expected_columns = ["id", "name", "role", "position", "seniority"]
+    expected_columns = ["id", "name", "role", "position", "seniority", "hire_date"]
     for col_name in expected_columns:
         assert col_name in columns, f"Column {col_name} is missing from 'users' table"
     # Validate primary key and coarse type expectations
@@ -74,3 +74,27 @@ def test_schema_generation_users_table(db_inspector: Inspector) -> None:
         assert ("char" in col_type) or ("text" in col_type), (
             f"'{col_name}' must be String-like"
         )
+
+
+def test_schema_generation_leave_requests_table(db_inspector: Inspector) -> None:
+    """Verify 'leave_requests' table exists with core leave management columns."""
+    tables = db_inspector.get_table_names()
+    assert "leave_requests" in tables, "Table 'leave_requests' is missing"
+
+    columns = {col["name"]: col for col in db_inspector.get_columns("leave_requests")}
+    expected_columns = [
+        "id",
+        "user_id",
+        "start_date",
+        "end_date",
+        "days_requested",
+        "status",
+        "created_at",
+    ]
+    for col_name in expected_columns:
+        assert col_name in columns, f"Column {col_name} is missing from 'leave_requests'"
+
+    pk = db_inspector.get_pk_constraint("leave_requests")
+    assert pk.get("constrained_columns") == ["id"], (
+        "Primary key for 'leave_requests' must be 'id'"
+    )

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import models
 import pytest
 from database import SessionLocal
+
+
+def _today_utc_date() -> date:
+    """Return today's date using a timezone-aware datetime source."""
+    return datetime.now(timezone.utc).date()
 
 
 @pytest.fixture(scope="session")
@@ -69,12 +74,12 @@ def test_leave_endpoints_are_registered(client: object) -> None:
 
 def test_create_leave_request_rejects_invalid_date_range(client: object) -> None:
     """Verify validation rejects payload where end_date is before start_date."""
-    user_id = _create_user_with_hire_date(date.today() - timedelta(days=365))
+    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=365))
     try:
         payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=10)).isoformat(),
-            "end_date": (date.today() + timedelta(days=9)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=9)).isoformat(),
         }
         response = client.post("/leave/request", json=payload)
         assert response.status_code == 422
@@ -86,8 +91,8 @@ def test_create_leave_request_rejects_unknown_user(client: object) -> None:
     """Verify create request returns 404 when user does not exist."""
     payload = {
         "user_id": 999_999_999,
-        "start_date": (date.today() + timedelta(days=10)).isoformat(),
-        "end_date": (date.today() + timedelta(days=10)).isoformat(),
+        "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
+        "end_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
     }
     response = client.post("/leave/request", json=payload)
     assert response.status_code == 404
@@ -97,12 +102,12 @@ def test_create_leave_request_rejects_unknown_user(client: object) -> None:
 def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> None:
     """Verify entitlement logic rejects a request when available balance is insufficient."""
     # Same-month hire date means earned days = 0 under current monthly accrual rule.
-    user_id = _create_user_with_hire_date(date.today())
+    user_id = _create_user_with_hire_date(_today_utc_date())
     try:
         payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=14)).isoformat(),
-            "end_date": (date.today() + timedelta(days=14)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
         }
         response = client.post("/leave/request", json=payload)
         assert response.status_code == 400
@@ -114,17 +119,17 @@ def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> N
 def test_create_leave_request_consumes_balance_for_future_requests(client: object) -> None:
     """Verify previously created non-rejected requests reduce remaining available balance."""
     # One month worked => 1.5 earned days, so only one 1-day request should succeed.
-    user_id = _create_user_with_hire_date(date.today() - timedelta(days=31))
+    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=31))
     try:
         first_payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=20)).isoformat(),
-            "end_date": (date.today() + timedelta(days=20)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=20)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=20)).isoformat(),
         }
         second_payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=21)).isoformat(),
-            "end_date": (date.today() + timedelta(days=21)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=21)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=21)).isoformat(),
         }
 
         first_response = client.post("/leave/request", json=first_payload)
@@ -139,17 +144,17 @@ def test_create_leave_request_consumes_balance_for_future_requests(client: objec
 
 def test_get_leave_history_is_newest_first(client: object) -> None:
     """Verify user leave history endpoint returns leave requests ordered newest first."""
-    user_id = _create_user_with_hire_date(date.today() - timedelta(days=730))
+    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=730))
     try:
         first_payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=30)).isoformat(),
-            "end_date": (date.today() + timedelta(days=30)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=30)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=30)).isoformat(),
         }
         second_payload = {
             "user_id": user_id,
-            "start_date": (date.today() + timedelta(days=40)).isoformat(),
-            "end_date": (date.today() + timedelta(days=41)).isoformat(),
+            "start_date": (_today_utc_date() + timedelta(days=40)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=41)).isoformat(),
         }
 
         first_response = client.post("/leave/request", json=first_payload)

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, timedelta
+
+import models
+import pytest
+from database import SessionLocal
+
+
+@pytest.fixture(scope="session")
+def client() -> object:
+    """Provide a TestClient for leave management integration tests."""
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        pytest.skip(
+            "DATABASE_URL is not configured; skipping leave management integration tests.",
+            allow_module_level=True,
+        )
+    from fastapi.testclient import TestClient
+    from main import app
+
+    return TestClient(app)
+
+
+def _create_user_with_hire_date(hire_date: date) -> int:
+    """Create a unique user record for test scenarios and return user id."""
+    db = SessionLocal()
+    try:
+        unique_suffix = uuid.uuid4().hex[:8]
+        user = models.User(
+            name=f"QA User {unique_suffix}",
+            role="User",
+            position="QA Engineer",
+            seniority="Mid",
+            hire_date=hire_date,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user.id
+    finally:
+        db.close()
+
+
+def _cleanup_user_data(user_id: int) -> None:
+    """Delete test leave requests and the associated user."""
+    db = SessionLocal()
+    try:
+        if hasattr(models, "LeaveRequest"):
+            db.query(models.LeaveRequest).filter(
+                models.LeaveRequest.user_id == user_id
+            ).delete()
+        db.query(models.User).filter(models.User.id == user_id).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_leave_endpoints_are_registered(client: object) -> None:
+    """Verify leave API routes are included in the FastAPI app."""
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json().get("paths", {})
+    assert "/leave/request" in paths
+    assert "/leave/my-requests/{user_id}" in paths
+
+
+def test_create_leave_request_rejects_invalid_date_range(client: object) -> None:
+    """Verify validation rejects payload where end_date is before start_date."""
+    user_id = _create_user_with_hire_date(date.today() - timedelta(days=365))
+    try:
+        payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=10)).isoformat(),
+            "end_date": (date.today() + timedelta(days=9)).isoformat(),
+        }
+        response = client.post("/leave/request", json=payload)
+        assert response.status_code == 422
+    finally:
+        _cleanup_user_data(user_id)
+
+
+def test_create_leave_request_rejects_unknown_user(client: object) -> None:
+    """Verify create request returns 404 when user does not exist."""
+    payload = {
+        "user_id": 999_999_999,
+        "start_date": (date.today() + timedelta(days=10)).isoformat(),
+        "end_date": (date.today() + timedelta(days=10)).isoformat(),
+    }
+    response = client.post("/leave/request", json=payload)
+    assert response.status_code == 404
+    assert response.json().get("detail") == "User not found"
+
+
+def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> None:
+    """Verify entitlement logic rejects a request when available balance is insufficient."""
+    # Same-month hire date means earned days = 0 under current monthly accrual rule.
+    user_id = _create_user_with_hire_date(date.today())
+    try:
+        payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=14)).isoformat(),
+            "end_date": (date.today() + timedelta(days=14)).isoformat(),
+        }
+        response = client.post("/leave/request", json=payload)
+        assert response.status_code == 400
+        assert "Not enough leave days" in response.json().get("detail", "")
+    finally:
+        _cleanup_user_data(user_id)
+
+
+def test_create_leave_request_consumes_balance_for_future_requests(client: object) -> None:
+    """Verify previously created non-rejected requests reduce remaining available balance."""
+    # One month worked => 1.5 earned days, so only one 1-day request should succeed.
+    user_id = _create_user_with_hire_date(date.today() - timedelta(days=31))
+    try:
+        first_payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=20)).isoformat(),
+            "end_date": (date.today() + timedelta(days=20)).isoformat(),
+        }
+        second_payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=21)).isoformat(),
+            "end_date": (date.today() + timedelta(days=21)).isoformat(),
+        }
+
+        first_response = client.post("/leave/request", json=first_payload)
+        assert first_response.status_code == 201
+
+        second_response = client.post("/leave/request", json=second_payload)
+        assert second_response.status_code == 400
+        assert "Not enough leave days" in second_response.json().get("detail", "")
+    finally:
+        _cleanup_user_data(user_id)
+
+
+def test_get_leave_history_is_newest_first(client: object) -> None:
+    """Verify user leave history endpoint returns leave requests ordered newest first."""
+    user_id = _create_user_with_hire_date(date.today() - timedelta(days=730))
+    try:
+        first_payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=30)).isoformat(),
+            "end_date": (date.today() + timedelta(days=30)).isoformat(),
+        }
+        second_payload = {
+            "user_id": user_id,
+            "start_date": (date.today() + timedelta(days=40)).isoformat(),
+            "end_date": (date.today() + timedelta(days=41)).isoformat(),
+        }
+
+        first_response = client.post("/leave/request", json=first_payload)
+        assert first_response.status_code == 201
+        first_id = first_response.json()["id"]
+
+        second_response = client.post("/leave/request", json=second_payload)
+        assert second_response.status_code == 201
+        second_id = second_response.json()["id"]
+
+        history_response = client.get(f"/leave/my-requests/{user_id}")
+        assert history_response.status_code == 200
+
+        requests = history_response.json()
+        assert len(requests) >= 2
+        assert requests[0]["id"] == second_id
+        assert requests[1]["id"] == first_id
+    finally:
+        _cleanup_user_data(user_id)

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -116,7 +116,9 @@ def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> N
         _cleanup_user_data(user_id)
 
 
-def test_create_leave_request_consumes_balance_for_future_requests(client: object) -> None:
+def test_create_leave_request_consumes_balance_for_future_requests(
+    client: object,
+) -> None:
     """Verify previously created non-rejected requests reduce remaining available balance."""
     # One month worked => 1.5 earned days, so only one 1-day request should succeed.
     user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=31))


### PR DESCRIPTION
## 🎯 Objective
Resolves #25.
This Pull Request introduces the core business logic of the application: the End-to-End Leave Management System. It transitions the project from a structural foundation to delivering real functional value by implementing database persistence for leave requests and dynamic entitlement calculations.

## 🛠️ Changes Implemented
* **Database Models (`models.py`):** * Added the `LeaveRequest` table with a foreign key relation to `users`.
  * Updated the `User` model to include `hire_date`, which is required for entitlement calculation.
* **Data Validation (`schemas.py`):** * Implemented Pydantic V2 schemas (`LeaveRequestCreate` and `LeaveRequestResponse`).
  * Added strict business rule validation ensuring `end_date` is always strictly after or equal to `start_date`.
* **Business Logic & Endpoints (`routers/leave.py`):**
  * `POST /leave/request`: Creates a new request, verifying user existence and calculating if the requested days exceed the available balance (1.5 days/month earned minus days already used).
  * `GET /leave/my-requests/{user_id}`: Retrieves a user's entire leave history ordered chronologically (newest first).
* **Application Wiring (`main.py`):** Registered the new `leave` router into the FastAPI app lifecycle.

## 🧪 How to Test
1. Switch to this branch: `git checkout feature/25-leave-management`
2. Start the database (via Docker or natively) and run the server: `uvicorn main:app --reload`
3. Navigate to Swagger UI at `http://localhost:8000/docs`.
4. Create a test user via direct DB insertion or the existing `users` logic (ensure they have a `hire_date`).
5. Execute `POST /leave/request` and verify that requests exceeding the 1.5 days/month calculation are successfully rejected with a `400 Bad Request`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit leave requests with server-side validation, clear errors for insufficient balance or missing users; days computed from inclusive date ranges and hire date.
  * View a user's leave history ordered newest-first with status tracking (PENDING/APPROVED/REJECTED).
* **Documentation**
  * Added database reset & seeding instructions (warning: permanently deletes local data).
* **Tests**
  * Added integration tests covering endpoint registration, validations, balance enforcement, consumption of future approved leave, and history ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->