### PR TITLE
feat(frontend): add Leave Management UI with create request + history

### DIFF
--- a/backend/bootstrap.py
+++ b/backend/bootstrap.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import date
+
+import models
+from database import SessionLocal, engine
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+DEFAULT_USERS = [
+    {
+        "id": 1,
+        "name": "Ion Popescu",
+        "role": models.RoleEnum.user.value,
+        "position": "Backend Developer",
+        "seniority": "Mid",
+        "hire_date": date(2022, 1, 15),
+    },
+    {
+        "id": 2,
+        "name": "Maria Ionescu",
+        "role": models.RoleEnum.manager.value,
+        "position": "Engineering Manager",
+        "seniority": "Senior",
+        "hire_date": date(2020, 5, 10),
+    },
+]
+
+
+def _users_has_hire_date_column() -> bool:
+    """Check if users table already contains the hire_date column."""
+    inspector = inspect(engine)
+    user_columns = {column["name"] for column in inspector.get_columns("users")}
+    return "hire_date" in user_columns
+
+
+def ensure_schema_compatibility() -> None:
+    """Apply backward-compatible schema fixes for legacy databases."""
+    inspector = inspect(engine)
+    if "users" not in inspector.get_table_names():
+        return
+
+    if _users_has_hire_date_column():
+        return
+
+    with engine.begin() as connection:
+        connection.execute(text("ALTER TABLE users ADD COLUMN hire_date DATE"))
+        if connection.dialect.name == "sqlite":
+            connection.execute(
+                text("UPDATE users SET hire_date = DATE('now') WHERE hire_date IS NULL")
+            )
+        else:
+            connection.execute(
+                text(
+                    "UPDATE users SET hire_date = CURRENT_DATE WHERE hire_date IS NULL"
+                )
+            )
+
+
+def seed_default_users_if_empty() -> None:
+    """Insert default users when database starts empty."""
+    db: Session = SessionLocal()
+    try:
+        if db.query(models.User.id).first() is not None:
+            return
+
+        db.add_all(
+            [
+                models.User(
+                    id=user["id"],
+                    name=user["name"],
+                    role=user["role"],
+                    position=user["position"],
+                    seniority=user["seniority"],
+                    hire_date=user["hire_date"],
+                )
+                for user in DEFAULT_USERS
+            ]
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import Generator
 
 import models
+from bootstrap import ensure_schema_compatibility, seed_default_users_if_empty
 from database import SessionLocal, engine
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -9,6 +10,8 @@ from routers import leave, users
 from sqlalchemy.orm import Session
 
 models.Base.metadata.create_all(bind=engine)
+ensure_schema_compatibility()
+seed_default_users_if_empty()
 
 app = FastAPI(
     title="API for Leave Management System",

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -1,11 +1,13 @@
 from collections.abc import Generator
 from datetime import date, datetime, timezone
+from typing import NoReturn
 
 import models
 import schemas
 from database import SessionLocal
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import desc
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/leave", tags=["Leave Management"])
@@ -42,6 +44,19 @@ def calculate_available_days(hire_date: date, used_days: int) -> float:
     return float(total_earned - used_days)
 
 
+def _raise_user_not_found() -> NoReturn:
+    raise HTTPException(status_code=404, detail="User not found")
+
+
+def _raise_insufficient_leave_days(
+    days_requested: int, available_days: float
+) -> NoReturn:
+    raise HTTPException(
+        status_code=400,
+        detail=f"Not enough leave days. Requested: {days_requested}, Available: {available_days}",
+    )
+
+
 @router.post(
     "/request",
     response_model=schemas.LeaveRequestResponse,
@@ -64,40 +79,47 @@ def create_leave_request(
     Raises:
         HTTPException: If user is not found or balance is insufficient.
     """
-    user = db.query(models.User).filter(models.User.id == request.user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    try:
+        user = db.query(models.User).filter(models.User.id == request.user_id).first()
+        if not user:
+            _raise_user_not_found()
 
-    days_requested = (request.end_date - request.start_date).days + 1
+        days_requested = (request.end_date - request.start_date).days + 1
 
-    approved_or_pending = (
-        db.query(models.LeaveRequest)
-        .filter(
-            models.LeaveRequest.user_id == user.id,
-            models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
+        approved_or_pending = (
+            db.query(models.LeaveRequest)
+            .filter(
+                models.LeaveRequest.user_id == user.id,
+                models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
+            )
+            .all()
         )
-        .all()
-    )
-    used_days = sum(req.days_requested for req in approved_or_pending)
+        used_days = sum(req.days_requested for req in approved_or_pending)
 
-    available_days = calculate_available_days(user.hire_date, used_days)
-    if days_requested > available_days:
+        available_days = calculate_available_days(user.hire_date, used_days)
+        if days_requested > available_days:
+            _raise_insufficient_leave_days(days_requested, available_days)
+
+        new_request = models.LeaveRequest(
+            user_id=request.user_id,
+            start_date=request.start_date,
+            end_date=request.end_date,
+            days_requested=days_requested,
+            status=models.LeaveStatusEnum.PENDING,
+        )
+
+        db.add(new_request)
+        db.commit()
+        db.refresh(new_request)
+    except HTTPException:
+        db.rollback()
+        raise
+    except SQLAlchemyError as err:
+        db.rollback()
         raise HTTPException(
-            status_code=400,
-            detail=f"Not enough leave days. Requested: {days_requested}, Available: {available_days}",
-        )
-
-    new_request = models.LeaveRequest(
-        user_id=request.user_id,
-        start_date=request.start_date,
-        end_date=request.end_date,
-        days_requested=days_requested,
-        status=models.LeaveStatusEnum.PENDING,
-    )
-
-    db.add(new_request)
-    db.commit()
-    db.refresh(new_request)
+            status_code=500,
+            detail="Could not create leave request due to a database error.",
+        ) from err
 
     return new_request
 
@@ -118,12 +140,18 @@ def get_user_leave_requests(
     Raises:
         HTTPException: If no requests are found.
     """
-    requests = (
-        db.query(models.LeaveRequest)
-        .filter(models.LeaveRequest.user_id == user_id)
-        .order_by(desc(models.LeaveRequest.created_at))
-        .all()
-    )
+    try:
+        requests = (
+            db.query(models.LeaveRequest)
+            .filter(models.LeaveRequest.user_id == user_id)
+            .order_by(desc(models.LeaveRequest.created_at))
+            .all()
+        )
+    except SQLAlchemyError as err:
+        raise HTTPException(
+            status_code=500,
+            detail="Could not load leave requests due to a database error.",
+        ) from err
 
     if not requests:
         raise HTTPException(

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,24 +1,22 @@
+from collections.abc import Generator
+
+import models
 import schemas
-from fastapi import APIRouter, HTTPException
+from database import SessionLocal
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 router = APIRouter(tags=["Users"])
 
-MOCK_USERS = [
-    {
-        "id": 1,
-        "name": "Ion Popescu",
-        "role": "User",
-        "position": "Backend Developer",
-        "seniority": "Mid",
-    },
-    {
-        "id": 2,
-        "name": "Maria Ionescu",
-        "role": "Manager",
-        "position": "Engineering Manager",
-        "seniority": "Senior",
-    },
-]
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a database session and ensure it is closed after use."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 @router.get("/health", status_code=200)
@@ -32,20 +30,24 @@ async def health_check() -> dict[str, str]:
 
 
 @router.get("/users", response_model=list[schemas.UserResponse])
-async def get_users() -> list[dict]:
+async def get_users(db: Session = Depends(get_db)) -> list[models.User]:
     """Return the list of all users.
 
     Returns:
-        A list of user dictionaries serialised via UserResponse.
+        A list of users serialised via UserResponse.
 
     Raises:
         HTTPException: 404 if no users exist.
-        HTTPException: 500 if an unexpected error occurs.
+        HTTPException: 500 if a database error occurs.
     """
-    if not MOCK_USERS:
-        raise HTTPException(status_code=404, detail="No users found")
     try:
-        return MOCK_USERS
-    except Exception as err:
-        # Return a generic 500 error without exposing internal exception details
-        raise HTTPException(status_code=500, detail="Internal server error") from err
+        users = db.query(models.User).order_by(models.User.id.asc()).all()
+    except SQLAlchemyError as err:
+        raise HTTPException(
+            status_code=500, detail="Could not load users from database."
+        ) from err
+
+    if not users:
+        raise HTTPException(status_code=404, detail="No users found")
+
+    return users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      ALLOWED_ORIGINS: http://localhost:5173,http://127.0.0.1:5173
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=/api

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HomePage } from './pages/HomePage';
+import { LeaveManagementPage } from './pages/LeaveManagementPage';
 import { UsersPage } from './pages/UsersPage';
 
 function App() {
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/users" element={<UsersPage />} />
+        <Route path="/leave" element={<LeaveManagementPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_BASE_URL = 'http://localhost:8000';
+const DEFAULT_API_BASE_URL = '/api';
 
 const configuredApiUrl = import.meta.env.VITE_API_URL?.trim();
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -280,6 +280,161 @@ code {
   gap: 0.8rem;
 }
 
+.toolbar-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.section-copy {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.leave-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 0.95rem;
+}
+
+.leave-form-card,
+.leave-history-card {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.leave-form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field span {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.field input,
+.field select {
+  min-height: 42px;
+  border-radius: 10px;
+  border: 1px solid #cbd8e3;
+  background: #ffffff;
+  padding: 0.56rem 0.68rem;
+  color: var(--text);
+  font-family: 'IBM Plex Sans', 'Trebuchet MS', sans-serif;
+  font-size: 0.95rem;
+}
+
+.field input:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid rgba(11, 125, 112, 0.4);
+  outline-offset: 1px;
+}
+
+.field-inline {
+  min-width: 210px;
+}
+
+.field-error {
+  margin: -0.1rem 0 0.2rem;
+  color: #8f231c;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.history-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.9rem;
+}
+
+.history-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.65rem;
+}
+
+.history-table-wrap {
+  border: 1px solid #d6e3eb;
+  border-radius: 14px;
+  background: #ffffff;
+  overflow-x: auto;
+}
+
+.history-table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+}
+
+.history-table th,
+.history-table td {
+  padding: 0.68rem 0.74rem;
+  border-bottom: 1px solid #e4edf3;
+  text-align: left;
+  font-size: 0.92rem;
+}
+
+.history-table th {
+  color: var(--text-muted);
+  background: #f8fbfd;
+  font-size: 0.73rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.history-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.16rem 0.54rem;
+  border: 1px solid transparent;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-chip-pending {
+  background: rgba(243, 155, 87, 0.17);
+  color: #8b541f;
+  border-color: rgba(243, 155, 87, 0.35);
+}
+
+.status-chip-approved {
+  background: rgba(11, 125, 112, 0.14);
+  color: #0a5f55;
+  border-color: rgba(11, 125, 112, 0.34);
+}
+
+.status-chip-rejected {
+  background: rgba(186, 50, 40, 0.14);
+  color: #8f231c;
+  border-color: rgba(186, 50, 40, 0.33);
+}
+
 .inline-link {
   color: #17405a;
   font-weight: 600;
@@ -512,6 +667,20 @@ code {
     align-items: stretch;
   }
 
+  .toolbar-links,
+  .history-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .leave-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .history-table {
+    min-width: 560px;
+  }
+
   .btn,
   .inline-link {
     justify-content: center;
@@ -521,5 +690,11 @@ code {
   .inline-link {
     border-bottom: none;
     padding: 0.2rem 0;
+  }
+}
+
+@media (max-width: 980px) {
+  .leave-layout {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -59,6 +59,10 @@ export function HomePage() {
           <Link className="btn btn-secondary" to="/users">
             Open Users Directory
           </Link>
+
+          <Link className="btn btn-secondary" to="/leave">
+            Open Leave Management
+          </Link>
         </div>
 
         {health && (

--- a/frontend/src/pages/LeaveManagementPage.tsx
+++ b/frontend/src/pages/LeaveManagementPage.tsx
@@ -1,0 +1,513 @@
+import { type FormEvent, useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AppHeader } from '../components/AppHeader';
+import {
+  ApiError,
+  createLeaveRequest,
+  getUserLeaveHistory,
+  getUsers,
+  type LeaveRequest,
+  type User,
+} from '../services/api';
+
+type LeaveFormState = {
+  userId: string;
+  startDate: string;
+  endDate: string;
+};
+
+const INITIAL_FORM_STATE: LeaveFormState = {
+  userId: '',
+  startDate: '',
+  endDate: '',
+};
+
+function formatDateValue(value: string): string {
+  const [yearText, monthText, dayText] = value.split('-');
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+
+  if (
+    Number.isNaN(year) ||
+    Number.isNaN(month) ||
+    Number.isNaN(day) ||
+    !yearText ||
+    !monthText ||
+    !dayText
+  ) {
+    return value;
+  }
+
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  }).format(date);
+}
+
+function formatDateTimeValue(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function getApiMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    return error.detail ?? error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function LeaveManagementPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [isUsersLoading, setIsUsersLoading] = useState(true);
+  const [usersError, setUsersError] = useState('');
+
+  const [formState, setFormState] =
+    useState<LeaveFormState>(INITIAL_FORM_STATE);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [formSuccess, setFormSuccess] = useState('');
+
+  const [historyUserId, setHistoryUserId] = useState('');
+  const [historyEntries, setHistoryEntries] = useState<LeaveRequest[]>([]);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState('');
+  const [historyEmptyMessage, setHistoryEmptyMessage] = useState(
+    'Select a user to load leave requests.',
+  );
+
+  const loadUsers = useCallback(async () => {
+    setIsUsersLoading(true);
+    setUsersError('');
+
+    try {
+      const data = await getUsers();
+      setUsers(data);
+
+      const fallbackUserId = data[0] ? String(data[0].id) : '';
+
+      setFormState((previous) => {
+        const hasCurrentUser = data.some(
+          (user) => String(user.id) === previous.userId,
+        );
+
+        return {
+          ...previous,
+          userId: hasCurrentUser ? previous.userId : fallbackUserId,
+        };
+      });
+
+      setHistoryUserId((previous) => {
+        const hasCurrentUser = data.some(
+          (user) => String(user.id) === previous,
+        );
+        return hasCurrentUser ? previous : fallbackUserId;
+      });
+
+      if (data.length === 0) {
+        setHistoryEntries([]);
+        setHistoryEmptyMessage(
+          'No users are available. Add users before creating leave requests.',
+        );
+      }
+    } catch (requestError) {
+      setUsers([]);
+      setUsersError(getApiMessage(requestError, 'Could not load users.'));
+      setFormState(INITIAL_FORM_STATE);
+      setHistoryUserId('');
+      setHistoryEntries([]);
+      setHistoryError('');
+      setHistoryEmptyMessage(
+        'Users are required before you can manage leave requests.',
+      );
+    } finally {
+      setIsUsersLoading(false);
+    }
+  }, []);
+
+  const loadHistory = useCallback(async (selectedUserId: string) => {
+    if (!selectedUserId) {
+      setHistoryEntries([]);
+      setHistoryError('');
+      setHistoryEmptyMessage('Select a user to load leave requests.');
+      return;
+    }
+
+    setIsHistoryLoading(true);
+    setHistoryError('');
+    setHistoryEmptyMessage('');
+
+    try {
+      const data = await getUserLeaveHistory(Number(selectedUserId));
+      setHistoryEntries(data);
+      if (data.length === 0) {
+        setHistoryEmptyMessage('No leave requests found for this user.');
+      }
+    } catch (requestError) {
+      if (requestError instanceof ApiError && requestError.status === 404) {
+        setHistoryEntries([]);
+        setHistoryError('');
+        setHistoryEmptyMessage(
+          requestError.detail ?? 'No leave requests found for this user.',
+        );
+      } else {
+        setHistoryEntries([]);
+        setHistoryError(
+          getApiMessage(requestError, 'Could not load leave request history.'),
+        );
+      }
+    } finally {
+      setIsHistoryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  useEffect(() => {
+    void loadHistory(historyUserId);
+  }, [historyUserId, loadHistory]);
+
+  const isDateRangeInvalid =
+    formState.startDate !== '' &&
+    formState.endDate !== '' &&
+    formState.endDate < formState.startDate;
+
+  const isSubmitDisabled =
+    isSubmitting ||
+    isUsersLoading ||
+    users.length === 0 ||
+    formState.userId === '' ||
+    formState.startDate === '' ||
+    formState.endDate === '' ||
+    isDateRangeInvalid;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError('');
+    setFormSuccess('');
+
+    if (!formState.userId || !formState.startDate || !formState.endDate) {
+      setFormError('Complete all form fields before submitting.');
+      return;
+    }
+
+    if (formState.endDate < formState.startDate) {
+      setFormError('End date must be on or after the start date.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await createLeaveRequest({
+        user_id: Number(formState.userId),
+        start_date: formState.startDate,
+        end_date: formState.endDate,
+      });
+
+      setFormSuccess('Leave request created successfully.');
+      setFormState((previous) => ({
+        ...previous,
+        startDate: '',
+        endDate: '',
+      }));
+
+      if (historyUserId !== formState.userId) {
+        setHistoryUserId(formState.userId);
+      }
+
+      await loadHistory(formState.userId);
+    } catch (requestError) {
+      if (requestError instanceof ApiError && requestError.status === 400) {
+        setFormError(
+          requestError.detail ??
+            'Not enough leave days. Select fewer days and try again.',
+        );
+      } else if (
+        requestError instanceof ApiError &&
+        requestError.status === 404
+      ) {
+        setFormError(
+          'Selected user was not found. Refresh users and choose a valid user.',
+        );
+      } else {
+        setFormError(
+          getApiMessage(requestError, 'Failed to create leave request.'),
+        );
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="page page-leave">
+      <div className="page-glow page-glow-a" aria-hidden="true" />
+      <div className="page-glow page-glow-b" aria-hidden="true" />
+
+      <AppHeader
+        title="Leave Management"
+        subtitle="REQUESTS AND HISTORY"
+        description="Create leave requests and review request history from the same dashboard."
+      />
+
+      <section className="card card-toolbar">
+        <div className="toolbar-links">
+          <Link className="inline-link" to="/">
+            Back to Home
+          </Link>
+          <Link className="inline-link" to="/users">
+            Open Users Directory
+          </Link>
+        </div>
+
+        <button
+          className="btn btn-secondary"
+          onClick={() => void loadUsers()}
+          type="button"
+          disabled={isUsersLoading}
+        >
+          {isUsersLoading ? 'Refreshing users...' : 'Refresh Users'}
+        </button>
+      </section>
+
+      {usersError && (
+        <section className="card status-panel status-panel-error">
+          <h2 className="section-title">Could not load users</h2>
+          <p>{usersError}</p>
+          <button
+            className="btn btn-primary"
+            onClick={() => void loadUsers()}
+            type="button"
+          >
+            Try Again
+          </button>
+        </section>
+      )}
+
+      {!usersError && (
+        <section className="leave-layout">
+          <article className="card leave-form-card">
+            <h2 className="section-title">Create Leave Request</h2>
+            <p className="section-copy">
+              Submit a new leave request and validate entitlement rules from the
+              backend.
+            </p>
+
+            <form className="leave-form" onSubmit={handleSubmit}>
+              <label className="field">
+                <span>User</span>
+                <select
+                  value={formState.userId}
+                  onChange={(event) =>
+                    setFormState((previous) => ({
+                      ...previous,
+                      userId: event.target.value,
+                    }))
+                  }
+                  disabled={
+                    isSubmitting || isUsersLoading || users.length === 0
+                  }
+                >
+                  {users.length === 0 ? (
+                    <option value="">No users available</option>
+                  ) : (
+                    users.map((user) => (
+                      <option key={user.id} value={String(user.id)}>
+                        {user.name} (#{user.id})
+                      </option>
+                    ))
+                  )}
+                </select>
+              </label>
+
+              <label className="field">
+                <span>Start date</span>
+                <input
+                  type="date"
+                  value={formState.startDate}
+                  onChange={(event) =>
+                    setFormState((previous) => ({
+                      ...previous,
+                      startDate: event.target.value,
+                    }))
+                  }
+                  disabled={
+                    isSubmitting || isUsersLoading || users.length === 0
+                  }
+                  required
+                />
+              </label>
+
+              <label className="field">
+                <span>End date</span>
+                <input
+                  type="date"
+                  value={formState.endDate}
+                  min={formState.startDate || undefined}
+                  onChange={(event) =>
+                    setFormState((previous) => ({
+                      ...previous,
+                      endDate: event.target.value,
+                    }))
+                  }
+                  disabled={
+                    isSubmitting || isUsersLoading || users.length === 0
+                  }
+                  aria-invalid={isDateRangeInvalid}
+                  required
+                />
+              </label>
+
+              {isDateRangeInvalid && (
+                <p className="field-error">
+                  End date must be on or after the start date.
+                </p>
+              )}
+
+              <button
+                className="btn btn-primary"
+                type="submit"
+                disabled={isSubmitDisabled}
+              >
+                {isSubmitting
+                  ? 'Submitting request...'
+                  : 'Submit Leave Request'}
+              </button>
+            </form>
+
+            {formSuccess && <p className="status ok">{formSuccess}</p>}
+            {formError && <p className="status error">{formError}</p>}
+          </article>
+
+          <article className="card leave-history-card">
+            <div className="history-header">
+              <div>
+                <h2 className="section-title">My Leave Requests</h2>
+                <p className="section-copy">
+                  Requests are displayed in newest-first order from the API.
+                </p>
+              </div>
+
+              <div className="history-controls">
+                <label className="field field-inline">
+                  <span>User</span>
+                  <select
+                    value={historyUserId}
+                    onChange={(event) => setHistoryUserId(event.target.value)}
+                    disabled={isUsersLoading || users.length === 0}
+                  >
+                    {users.length === 0 ? (
+                      <option value="">No users available</option>
+                    ) : (
+                      users.map((user) => (
+                        <option key={user.id} value={String(user.id)}>
+                          {user.name} (#{user.id})
+                        </option>
+                      ))
+                    )}
+                  </select>
+                </label>
+
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => void loadHistory(historyUserId)}
+                  type="button"
+                  disabled={!historyUserId || isHistoryLoading}
+                >
+                  {isHistoryLoading ? 'Refreshing...' : 'Refresh History'}
+                </button>
+              </div>
+            </div>
+
+            {isHistoryLoading && (
+              <p className="loading-text">
+                <span className="spinner" aria-hidden="true" />
+                Loading leave requests...
+              </p>
+            )}
+
+            {!isHistoryLoading && historyError && (
+              <section className="status-panel status-panel-error">
+                <h3 className="section-title">Could not load leave history</h3>
+                <p>{historyError}</p>
+                <button
+                  className="btn btn-primary"
+                  onClick={() => void loadHistory(historyUserId)}
+                  type="button"
+                >
+                  Retry
+                </button>
+              </section>
+            )}
+
+            {!isHistoryLoading &&
+              !historyError &&
+              historyEntries.length === 0 && (
+                <section className="status-panel">
+                  <h3 className="section-title">No leave requests</h3>
+                  <p>{historyEmptyMessage || 'No leave requests found.'}</p>
+                </section>
+              )}
+
+            {!isHistoryLoading &&
+              !historyError &&
+              historyEntries.length > 0 && (
+                <div className="history-table-wrap">
+                  <table className="history-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Start Date</th>
+                        <th scope="col">End Date</th>
+                        <th scope="col">Days</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Created At</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {historyEntries.map((requestEntry) => (
+                        <tr key={requestEntry.id}>
+                          <td>{formatDateValue(requestEntry.start_date)}</td>
+                          <td>{formatDateValue(requestEntry.end_date)}</td>
+                          <td>{requestEntry.days_requested}</td>
+                          <td>
+                            <span
+                              className={`status-chip status-chip-${requestEntry.status.toLowerCase()}`}
+                            >
+                              {requestEntry.status}
+                            </span>
+                          </td>
+                          <td>
+                            {formatDateTimeValue(requestEntry.created_at)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+          </article>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/LeaveManagementPage.tsx
+++ b/frontend/src/pages/LeaveManagementPage.tsx
@@ -233,9 +233,9 @@ export function LeaveManagementPage() {
 
       if (historyUserId !== formState.userId) {
         setHistoryUserId(formState.userId);
+      } else {
+        await loadHistory(formState.userId);
       }
-
-      await loadHistory(formState.userId);
     } catch (requestError) {
       if (requestError instanceof ApiError && requestError.status === 400) {
         setFormError(

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -43,9 +43,14 @@ export function UsersPage() {
       />
 
       <section className="card card-toolbar">
-        <Link className="inline-link" to="/">
-          Back to Home
-        </Link>
+        <div className="toolbar-links">
+          <Link className="inline-link" to="/">
+            Back to Home
+          </Link>
+          <Link className="inline-link" to="/leave">
+            Open Leave Management
+          </Link>
+        </div>
 
         <button
           className="btn btn-secondary"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,22 +13,91 @@ export type User = {
   seniority: string;
 };
 
-export async function getHealth(): Promise<HealthResponse> {
-  const response = await fetch(`${API_BASE_URL}/health`);
+export type LeaveStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
-  if (!response.ok) {
-    throw new Error(`Health check failed with status ${response.status}.`);
+export type LeaveRequest = {
+  id: number;
+  user_id: number;
+  start_date: string;
+  end_date: string;
+  days_requested: number;
+  status: LeaveStatus;
+  created_at: string;
+};
+
+export type CreateLeaveRequestPayload = {
+  user_id: number;
+  start_date: string;
+  end_date: string;
+};
+
+type ApiErrorPayload = {
+  detail?: string;
+};
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail?: string;
+
+  constructor(status: number, detail?: string) {
+    super(detail ?? `Request failed with status ${status}.`);
+    this.name = 'ApiError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+async function parseApiError(response: Response): Promise<ApiError> {
+  let detail: string | undefined;
+
+  try {
+    const errorPayload = (await response.json()) as ApiErrorPayload;
+    if (typeof errorPayload.detail === 'string') {
+      detail = errorPayload.detail;
+    }
+  } catch {
+    detail = undefined;
   }
 
-  return (await response.json()) as HealthResponse;
+  if (!response.ok) {
+    return new ApiError(response.status, detail);
+  }
+
+  return new ApiError(response.status);
+}
+
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, init);
+
+  if (!response.ok) {
+    throw await parseApiError(response);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function getHealth(): Promise<HealthResponse> {
+  return requestJson<HealthResponse>('/health');
 }
 
 export async function getUsers(): Promise<User[]> {
-  const response = await fetch(`${API_BASE_URL}/users`);
+  return requestJson<User[]>('/users');
+}
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch users');
-  }
+export async function createLeaveRequest(
+  payload: CreateLeaveRequestPayload,
+): Promise<LeaveRequest> {
+  return requestJson<LeaveRequest>('/leave/request', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+}
 
-  return response.json();
+export async function getUserLeaveHistory(
+  userId: number,
+): Promise<LeaveRequest[]> {
+  return requestJson<LeaveRequest[]>(`/leave/my-requests/${userId}`);
 }


### PR DESCRIPTION
Resolves #30

## Summary
Implement the frontend for Leave Management, so users can create leave requests and view their request history.

## Changes
- added `/leave` route and `LeaveManagementPage` page
- implemented controlled form with validations for:
- user
- start date
- end date
- integrated API:
- `POST /leave/request` for creating request
- `GET /leave/my-requests/{user_id} for history
- implemented history table (sort newest-first)
- added refresh button to re-fetch data
- added navigation from Home and Users to Leave Management
- improved UI:
- responsive layout
- states: loading / error / success

## Validation
- ESLint + Prettier on frontend
- manual test in browser:
- create leave request
- refresh history
- handling for API errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Leave Management page with form to submit leave requests and display request history by user, including date validation and status tracking (pending, approved, rejected).
  * Added navigation links to the new Leave Management page from the home and users pages.

* **Chores**
  * Updated API configuration to use relative paths instead of absolute local URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->