### PR TITLE
feat(backend): implement JWT auth, RBAC, and manager approval flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # DATABASE_URL for native local development (running backend outside Docker)
 # Adjust port/host to match your local PostgreSQL instance
 DATABASE_URL=postgresql://postgres:your_password_here@localhost:5433/mpi_db
+
+JWT_SECRET=super-secret-development-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         run: pytest backend/tests
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mpi_db
+          JWT_SECRET: super-secret-test-key-for-ci
 
   frontend:
     name: Frontend (lint + build)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ import models
 from database import SessionLocal, engine
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import leave, users
+from routers import auth, leave, users
 from sqlalchemy.orm import Session
 
 models.Base.metadata.create_all(bind=engine)
@@ -53,5 +53,6 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
+app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(leave.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -22,14 +22,15 @@ class LeaveStatusEnum(str, enum.Enum):
     REJECTED = "REJECTED"
 
 
+# backend/models.py
 class User(Base):
     """Database model representing an employee/user in the system."""
 
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
-    password_hash = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=True)
+    password_hash = Column(String, nullable=True)
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/models.py
+++ b/backend/models.py
@@ -30,7 +30,9 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     name = Column(String, nullable=False)
     role = Column(String, nullable=False, default=RoleEnum.user.value)
@@ -54,10 +56,12 @@ class LeaveRequest(Base):
     end_date = Column(Date, nullable=False)
     days_requested = Column(Integer, nullable=False)
     status = Column(SQLEnum(LeaveStatusEnum), default=LeaveStatusEnum.PENDING)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     reviewed_by = Column(Integer, ForeignKey("users.id"), nullable=True)
-    reviewed_at = Column(DateTime, nullable=True)
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
     rejection_reason = Column(String, nullable=True)
 
     user = relationship("User", foreign_keys=[user_id], back_populates="leave_requests")

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,13 +28,19 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
     name = Column(String, nullable=False)
     role = Column(String, nullable=False, default=RoleEnum.user.value)
     position = Column(String, nullable=False)
     seniority = Column(String, nullable=False)
     hire_date = Column(Date, nullable=False, default=date.today)
 
-    leave_requests = relationship("LeaveRequest", back_populates="user")
+    leave_requests = relationship(
+        "LeaveRequest", foreign_keys="[LeaveRequest.user_id]", back_populates="user"
+    )
 
 
 class LeaveRequest(Base):
@@ -50,4 +56,9 @@ class LeaveRequest(Base):
     status = Column(SQLEnum(LeaveStatusEnum), default=LeaveStatusEnum.PENDING)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
-    user = relationship("User", back_populates="leave_requests")
+    reviewed_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+    reviewed_at = Column(DateTime, nullable=True)
+    rejection_reason = Column(String, nullable=True)
+
+    user = relationship("User", foreign_keys=[user_id], back_populates="leave_requests")
+    reviewer = relationship("User", foreign_keys=[reviewed_by])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110.0
 uvicorn>=0.28.0
+pydantic[email]>=2.7.0
 pydantic>=2.7.0
 sqlalchemy>=2.0.23
 psycopg2-binary>=2.9.9

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,6 @@ sqlalchemy>=2.0.23
 psycopg2-binary>=2.9.9
 python-dotenv>=1.0.0
 httpx>=0.23.0
+passlib[bcrypt]>=1.7.4
+PyJWT>=2.8.0
+python-multipart>=0.0.9

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -8,6 +8,8 @@ from database import SessionLocal, engine
 def get_password_hash(password: str) -> str:
     """Generează hash-ul pentru o parolă folosind direct librăria bcrypt."""
     pwd_bytes = password.encode("utf-8")
+    if len(pwd_bytes) > 72:
+        raise ValueError("Password exceeds 72 bytes after UTF-8 encoding")
     salt = bcrypt.gensalt()
     hashed_password = bcrypt.hashpw(pwd_bytes, salt)
     return hashed_password.decode("utf-8")

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-import bcrypt  # <-- Folosim direct bcrypt în loc de passlib
+import bcrypt
 import models
 from database import SessionLocal, engine
 
@@ -24,7 +24,6 @@ def reset_and_seed() -> None:
     print("🌱 Seeding mock users...")
     db = SessionLocal()
     try:
-        # Generăm o parolă standard ("password123") criptată
         default_password = get_password_hash("password123")
 
         mock_users = [

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,7 +1,16 @@
 from datetime import date
 
+import bcrypt  # <-- Folosim direct bcrypt în loc de passlib
 import models
 from database import SessionLocal, engine
+
+
+def get_password_hash(password: str) -> str:
+    """Generează hash-ul pentru o parolă folosind direct librăria bcrypt."""
+    pwd_bytes = password.encode("utf-8")
+    salt = bcrypt.gensalt()
+    hashed_password = bcrypt.hashpw(pwd_bytes, salt)
+    return hashed_password.decode("utf-8")
 
 
 def reset_and_seed() -> None:
@@ -15,25 +24,35 @@ def reset_and_seed() -> None:
     print("🌱 Seeding mock users...")
     db = SessionLocal()
     try:
+        # Generăm o parolă standard ("password123") criptată
+        default_password = get_password_hash("password123")
+
         mock_users = [
             models.User(
+                email="ion@example.com",
+                password_hash=default_password,
                 name="Ion Popescu",
                 role=models.RoleEnum.user.value,
                 position="Backend Developer",
                 seniority="Mid",
-                hire_date=date(2022, 1, 15),  # Angajat in 2022
+                hire_date=date(2022, 1, 15),
             ),
             models.User(
+                email="maria@example.com",
+                password_hash=default_password,
                 name="Maria Ionescu",
                 role=models.RoleEnum.manager.value,
                 position="Engineering Manager",
                 seniority="Senior",
-                hire_date=date(2020, 5, 10),  # Angajata in 2020
+                hire_date=date(2020, 5, 10),
             ),
         ]
         db.add_all(mock_users)
         db.commit()
         print("✅ Database reset and seeded successfully!")
+        print("🔑 Test accounts:")
+        print("   - User: ion@example.com / password123")
+        print("   - Manager: maria@example.com / password123")
     except Exception as e:
         print(f"❌ An error occurred during seeding: {e}")
         db.rollback()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,131 @@
+import os
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+import jwt
+import models
+import schemas
+from database import SessionLocal
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+SECRET_KEY = os.getenv("JWT_SECRET", "super-secret-development-key")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a database session and ensure it is closed after use."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verifică dacă o parolă text se potrivește cu hash-ul salvat."""
+    pwd_bytes = plain_password.encode("utf-8")
+    hash_bytes = hashed_password.encode("utf-8")
+    return bcrypt.checkpw(pwd_bytes, hash_bytes)
+
+
+def get_password_hash(password: str) -> str:
+    """Generează un hash bcrypt dintr-o parolă text."""
+    pwd_bytes = password.encode("utf-8")
+    salt = bcrypt.gensalt()
+    hashed_password = bcrypt.hashpw(pwd_bytes, salt)
+    return hashed_password.decode("utf-8")
+
+
+def create_access_token(data: dict) -> str:
+    """Generează un token JWT valid pentru sesiunea utilizatorului."""
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+@router.post(
+    "/register",
+    response_model=schemas.UserResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def register(user: schemas.UserCreate, db: Session = Depends(get_db)) -> models.User:
+    """Înregistrează un utilizator nou cu rol implicit de 'User'."""
+    db_user = db.query(models.User).filter(models.User.email == user.email).first()
+    if db_user:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
+    hashed_password = get_password_hash(user.password)
+
+    new_user = models.User(
+        email=user.email,
+        password_hash=hashed_password,
+        name=user.name,
+        position=user.position,
+        seniority=user.seniority,
+        role=models.RoleEnum.user.value,
+    )
+
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    return new_user
+
+
+@router.post("/login", response_model=schemas.Token)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+) -> dict[str, str]:
+    """Autentifică utilizatorul și returnează un JWT Bearer Token."""
+    user = db.query(models.User).filter(models.User.email == form_data.username).first()
+
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token = create_access_token(data={"sub": str(user.id), "role": user.role})
+
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+) -> models.User:
+    """Decodifică JWT-ul, validează sesiunea și returnează utilizatorul."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str | None = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except jwt.InvalidTokenError as err:
+        raise credentials_exception from err
+
+    user = db.query(models.User).filter(models.User.id == int(user_id)).first()
+    if user is None:
+        raise credentials_exception
+
+    return user
+
+
+@router.get("/me", response_model=schemas.UserResponse)
+def read_users_me(current_user: models.User = Depends(get_current_user)) -> models.User:
+    """Returnează profilul utilizatorului autentificat în prezent."""
+    return current_user

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,7 +13,12 @@ from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
-SECRET_KEY = os.getenv("JWT_SECRET", "super-secret-development-key")
+SECRET_KEY = os.getenv("JWT_SECRET")
+if not SECRET_KEY:
+    raise RuntimeError(
+        "FATAL: JWT_SECRET environment variable must be set. Check your .env file."
+    )
+
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,3 +1,4 @@
+# backend/routers/auth.py
 import os
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
@@ -8,7 +9,8 @@ import models
 import schemas
 from database import SessionLocal
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
@@ -23,6 +25,13 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+class LoginRequest(BaseModel):
+    """Schema for login requests."""
+
+    username: str
+    password: str
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -87,13 +96,13 @@ def register(user: schemas.UserCreate, db: Session = Depends(get_db)) -> models.
 
 
 @router.post("/login", response_model=schemas.Token)
-def login(
-    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
-) -> dict[str, str]:
+def login(credentials: LoginRequest, db: Session = Depends(get_db)) -> dict[str, str]:
     """Autentifică utilizatorul și returnează un JWT Bearer Token."""
-    user = db.query(models.User).filter(models.User.email == form_data.username).first()
+    user = (
+        db.query(models.User).filter(models.User.email == credentials.username).first()
+    )
 
-    if not user or not verify_password(form_data.password, user.password_hash):
+    if not user or not verify_password(credentials.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -123,7 +123,12 @@ def get_current_user(
     except jwt.InvalidTokenError as err:
         raise credentials_exception from err
 
-    user = db.query(models.User).filter(models.User.id == int(user_id)).first()
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError) as err:
+        raise credentials_exception from err
+
+    user = db.query(models.User).filter(models.User.id == user_id_int).first()
     if user is None:
         raise credentials_exception
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -22,7 +22,7 @@ if not SECRET_KEY:
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 
 
 def get_db() -> Generator[Session, None, None]:

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -5,6 +5,7 @@ import models
 import schemas
 from database import SessionLocal
 from fastapi import APIRouter, Depends, HTTPException, status
+from routers.auth import get_current_user
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
@@ -12,11 +13,7 @@ router = APIRouter(prefix="/leave", tags=["Leave Management"])
 
 
 def get_db() -> Generator[Session, None, None]:
-    """Dependency to provide a database session.
-
-    Yields:
-        Session: A SQLAlchemy database session.
-    """
+    """Dependency to provide a database session."""
     db = SessionLocal()
     try:
         yield db
@@ -25,17 +22,7 @@ def get_db() -> Generator[Session, None, None]:
 
 
 def calculate_available_days(hire_date: date, used_days: int) -> float:
-    """Calculate the available leave days based on months worked.
-
-    Rule: 1.5 leave days per month worked.
-
-    Args:
-        hire_date: The date the employee was hired.
-        used_days: The number of days already approved or pending.
-
-    Returns:
-        The remaining leave balance.
-    """
+    """Calculate the available leave days based on months worked."""
     today = datetime.now(timezone.utc).date()
     months_worked = (today.year - hire_date.year) * 12 + (today.month - hire_date.month)
     total_earned = max(0, months_worked * 1.5)
@@ -48,39 +35,41 @@ def calculate_available_days(hire_date: date, used_days: int) -> float:
     status_code=status.HTTP_201_CREATED,
 )
 def create_leave_request(
-    request: schemas.LeaveRequestCreate, db: Session = Depends(get_db)
+    request: schemas.LeaveRequestCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
 ) -> models.LeaveRequest:
-    """Create a new leave request for a user.
-
-    Validates if the user exists and has enough leave balance.
-
-    Args:
-        request: The leave request payload containing dates.
-        db: The database session.
-
-    Returns:
-        The created leave request record.
-
-    Raises:
-        HTTPException: If user is not found or balance is insufficient.
-    """
-    user = db.query(models.User).filter(models.User.id == request.user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-
+    """Create a new leave request for the currently authenticated user."""
     days_requested = (request.end_date - request.start_date).days + 1
+
+    overlapping_request = (
+        db.query(models.LeaveRequest)
+        .filter(
+            models.LeaveRequest.user_id == current_user.id,
+            models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
+            # Logica de suprapunere: Start1 <= End2 ȘI End1 >= Start2
+            models.LeaveRequest.start_date <= request.end_date,
+            models.LeaveRequest.end_date >= request.start_date,
+        )
+        .first()
+    )
+    if overlapping_request:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Requested dates overlap with an existing request (ID: {overlapping_request.id})",
+        )
 
     approved_or_pending = (
         db.query(models.LeaveRequest)
         .filter(
-            models.LeaveRequest.user_id == user.id,
+            models.LeaveRequest.user_id == current_user.id,
             models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
         )
         .all()
     )
     used_days = sum(req.days_requested for req in approved_or_pending)
 
-    available_days = calculate_available_days(user.hire_date, used_days)
+    available_days = calculate_available_days(current_user.hire_date, used_days)
     if days_requested > available_days:
         raise HTTPException(
             status_code=400,
@@ -88,7 +77,7 @@ def create_leave_request(
         )
 
     new_request = models.LeaveRequest(
-        user_id=request.user_id,
+        user_id=current_user.id,
         start_date=request.start_date,
         end_date=request.end_date,
         days_requested=days_requested,
@@ -102,32 +91,125 @@ def create_leave_request(
     return new_request
 
 
-@router.get("/my-requests/{user_id}", response_model=list[schemas.LeaveRequestResponse])
+@router.get("/my-requests", response_model=list[schemas.LeaveRequestResponse])
 def get_user_leave_requests(
-    user_id: int, db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
 ) -> list[models.LeaveRequest]:
-    """Retrieve all leave requests for a specific user.
-
-    Args:
-        user_id: The ID of the user.
-        db: The database session.
-
-    Returns:
-        A list of leave requests ordered chronologically (newest first).
-
-    Raises:
-        HTTPException: If no requests are found.
-    """
+    """Retrieve all leave requests for the currently authenticated user."""
     requests = (
         db.query(models.LeaveRequest)
-        .filter(models.LeaveRequest.user_id == user_id)
+        .filter(models.LeaveRequest.user_id == current_user.id)
         .order_by(desc(models.LeaveRequest.created_at))
         .all()
     )
 
     if not requests:
         raise HTTPException(
-            status_code=404, detail="No leave requests found for this user"
+            status_code=404, detail="No leave requests found for your account"
         )
 
     return requests
+
+
+def require_manager(
+    current_user: models.User = Depends(get_current_user),
+) -> models.User:
+    """Dependency care blochează accesul utilizatorilor simpli (HTTP 403 Forbidden)."""
+    if current_user.role != models.RoleEnum.manager.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation restricted to Managers only",
+        )
+    return current_user
+
+
+@router.get("/requests", response_model=list[schemas.LeaveRequestResponse])
+def get_all_pending_requests(
+    db: Session = Depends(get_db),
+    manager: models.User = Depends(require_manager),  # <-- Doar managerii trec de asta!
+) -> list[models.LeaveRequest]:
+    """Retrieve all PENDING leave requests across the company (Manager only)."""
+    requests = (
+        db.query(models.LeaveRequest)
+        .filter(models.LeaveRequest.status == models.LeaveStatusEnum.PENDING)
+        .order_by(desc(models.LeaveRequest.created_at))
+        .all()
+    )
+    return requests
+
+
+@router.patch(
+    "/requests/{request_id}/approve", response_model=schemas.LeaveRequestResponse
+)
+def approve_leave_request(
+    request_id: int,
+    db: Session = Depends(get_db),
+    manager: models.User = Depends(require_manager),
+) -> models.LeaveRequest:
+    """Approve a specific pending leave request (Manager only)."""
+    leave_req = (
+        db.query(models.LeaveRequest)
+        .filter(models.LeaveRequest.id == request_id)
+        .first()
+    )
+
+    if not leave_req:
+        raise HTTPException(status_code=404, detail="Leave request not found")
+
+    if leave_req.status != models.LeaveStatusEnum.PENDING:
+        raise HTTPException(
+            status_code=400, detail="Only PENDING requests can be approved"
+        )
+
+    if leave_req.user_id == manager.id:
+        raise HTTPException(
+            status_code=403, detail="Managers cannot approve their own requests"
+        )
+
+    leave_req.status = models.LeaveStatusEnum.APPROVED
+    leave_req.reviewed_by = manager.id
+    leave_req.reviewed_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(leave_req)
+    return leave_req
+
+
+@router.patch(
+    "/requests/{request_id}/reject", response_model=schemas.LeaveRequestResponse
+)
+def reject_leave_request(
+    request_id: int,
+    payload: schemas.LeaveReject,
+    db: Session = Depends(get_db),
+    manager: models.User = Depends(require_manager),
+) -> models.LeaveRequest:
+    """Reject a specific pending leave request with an optional reason (Manager only)."""
+    leave_req = (
+        db.query(models.LeaveRequest)
+        .filter(models.LeaveRequest.id == request_id)
+        .first()
+    )
+
+    if not leave_req:
+        raise HTTPException(status_code=404, detail="Leave request not found")
+
+    if leave_req.status != models.LeaveStatusEnum.PENDING:
+        raise HTTPException(
+            status_code=400, detail="Only PENDING requests can be rejected"
+        )
+
+    if leave_req.user_id == manager.id:
+        raise HTTPException(
+            status_code=403, detail="Managers cannot reject their own requests"
+        )
+
+    leave_req.status = models.LeaveStatusEnum.REJECTED
+    leave_req.reviewed_by = manager.id
+    leave_req.reviewed_at = datetime.now(timezone.utc)
+    leave_req.rejection_reason = payload.rejection_reason
+
+    db.commit()
+    db.refresh(leave_req)
+    return leave_req

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -146,6 +146,7 @@ def approve_leave_request(
     leave_req = (
         db.query(models.LeaveRequest)
         .filter(models.LeaveRequest.id == request_id)
+        .with_for_update()
         .first()
     )
 
@@ -184,6 +185,7 @@ def reject_leave_request(
     leave_req = (
         db.query(models.LeaveRequest)
         .filter(models.LeaveRequest.id == request_id)
+        .with_for_update()
         .first()
     )
 

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 import models
 import schemas
 from database import SessionLocal
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from routers.auth import get_current_user
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
@@ -47,7 +47,6 @@ def create_leave_request(
         .filter(
             models.LeaveRequest.user_id == current_user.id,
             models.LeaveRequest.status != models.LeaveStatusEnum.REJECTED,
-            # Logica de suprapunere: Start1 <= End2 ȘI End1 >= Start2
             models.LeaveRequest.start_date <= request.end_date,
             models.LeaveRequest.end_date >= request.start_date,
         )
@@ -120,14 +119,15 @@ def require_manager(
 
 
 @router.get("/requests", response_model=list[schemas.LeaveRequestResponse])
-def get_all_pending_requests(
+def get_all_requests(
+    leave_status: models.LeaveStatusEnum = Query(models.LeaveStatusEnum.PENDING),
     db: Session = Depends(get_db),
-    manager: models.User = Depends(require_manager),  # <-- Doar managerii trec de asta!
+    manager: models.User = Depends(require_manager),
 ) -> list[models.LeaveRequest]:
-    """Retrieve all PENDING leave requests across the company (Manager only)."""
+    """Retrieve leave requests across the company, filtered by status (Manager only)."""
     requests = (
         db.query(models.LeaveRequest)
-        .filter(models.LeaveRequest.status == models.LeaveStatusEnum.PENDING)
+        .filter(models.LeaveRequest.status == leave_status)
         .order_by(desc(models.LeaveRequest.created_at))
         .all()
     )

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -55,7 +55,7 @@ def create_leave_request(
     )
     if overlapping_request:
         raise HTTPException(
-            status_code=400,
+            status_code=status.HTTP_409_CONFLICT,
             detail=f"Requested dates overlap with an existing request (ID: {overlapping_request.id})",
         )
 

--- a/backend/routers/leave.py
+++ b/backend/routers/leave.py
@@ -104,11 +104,6 @@ def get_user_leave_requests(
         .all()
     )
 
-    if not requests:
-        raise HTTPException(
-            status_code=404, detail="No leave requests found for your account"
-        )
-
     return requests
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -6,6 +6,8 @@ router = APIRouter(tags=["Users"])
 MOCK_USERS = [
     {
         "id": 1,
+        "email": "ion.popescu@company.com",
+        "password_hash": "hashed_password_1",
         "name": "Ion Popescu",
         "role": "User",
         "position": "Backend Developer",
@@ -13,6 +15,8 @@ MOCK_USERS = [
     },
     {
         "id": 2,
+        "email": "maria.ionescu@company.com",
+        "password_hash": "hashed_password_2",
         "name": "Maria Ionescu",
         "role": "Manager",
         "position": "Engineering Manager",

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -47,5 +47,4 @@ async def get_users() -> list[dict]:
     try:
         return MOCK_USERS
     except Exception as err:
-        # Return a generic 500 error without exposing internal exception details
         raise HTTPException(status_code=500, detail="Internal server error") from err

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class LeaveStatus(str, Enum):
@@ -46,8 +46,8 @@ class LeaveRequestResponse(BaseModel):
 class UserCreate(BaseModel):
     """Schema for registering a new user."""
 
-    email: str
-    password: str
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=72)
     name: str
     position: str
     seniority: str

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -15,20 +15,12 @@ class LeaveStatus(str, Enum):
 class LeaveRequestCreate(BaseModel):
     """Schema for creating a new leave request."""
 
-    user_id: int
     start_date: date
     end_date: date
 
     @model_validator(mode="after")
     def validate_dates(self) -> "LeaveRequestCreate":
-        """Ensure end_date is after or equal to start_date.
-
-        Returns:
-            The validated model.
-
-        Raises:
-            ValueError: If end_date is before start_date.
-        """
+        """Ensure end_date is after or equal to start_date."""
         if self.end_date < self.start_date:
             raise ValueError("end_date must be strictly after or equal to start_date")
         return self
@@ -44,17 +36,44 @@ class LeaveRequestResponse(BaseModel):
     days_requested: int
     status: LeaveStatus
     created_at: datetime
+    reviewed_by: int | None = None
+    reviewed_at: datetime | None = None
+    rejection_reason: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class UserCreate(BaseModel):
+    """Schema for registering a new user."""
+
+    email: str
+    password: str
+    name: str
+    position: str
+    seniority: str
 
 
 class UserResponse(BaseModel):
     """Schema for returning user data to the client."""
 
     id: int
+    email: str
     name: str
     role: str
     position: str
     seniority: str
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class Token(BaseModel):
+    """Schema for the JWT access token."""
+
+    access_token: str
+    token_type: str
+
+
+class LeaveReject(BaseModel):
+    """Schema for rejecting a leave request."""
+
+    rejection_reason: str | None = None

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -1,10 +1,11 @@
+# backend/tests/test_leave_management.py
 from __future__ import annotations
 
-import hashlib
 import os
 import uuid
 from datetime import date, datetime, timedelta, timezone
 
+import bcrypt
 import models
 import pytest
 from database import SessionLocal
@@ -49,6 +50,14 @@ def client() -> object:
     return client
 
 
+def _get_password_hash(password: str) -> str:
+    """Generate a bcrypt hash for a password."""
+    pwd_bytes = password.encode("utf-8")
+    salt = bcrypt.gensalt()
+    hashed_password = bcrypt.hashpw(pwd_bytes, salt)
+    return hashed_password.decode("utf-8")
+
+
 def _create_user_with_hire_date(hire_date: date) -> tuple[int, str]:
     """Create a unique user record for test scenarios and return (user_id, password)."""
     db = SessionLocal()
@@ -56,7 +65,7 @@ def _create_user_with_hire_date(hire_date: date) -> tuple[int, str]:
         unique_suffix = uuid.uuid4().hex[:8]
         email = f"qa.user.{unique_suffix}@example.com"
         password = f"password_{unique_suffix}"
-        password_hash = hashlib.sha256(password.encode()).hexdigest()
+        password_hash = _get_password_hash(password)
 
         user = models.User(
             email=email,

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -58,8 +58,8 @@ def _get_password_hash(password: str) -> str:
     return hashed_password.decode("utf-8")
 
 
-def _create_user_with_hire_date(hire_date: date) -> tuple[int, str]:
-    """Create a unique user record for test scenarios and return (user_id, password)."""
+def _create_user_with_hire_date(hire_date: date) -> tuple[int, str, str]:
+    """Create a unique user record for test scenarios and return (user_id, email, password)."""
     db = SessionLocal()
     try:
         unique_suffix = uuid.uuid4().hex[:8]
@@ -79,7 +79,7 @@ def _create_user_with_hire_date(hire_date: date) -> tuple[int, str]:
         db.add(user)
         db.commit()
         db.refresh(user)
-        return user.id, password
+        return user.id, email, password
     finally:
         db.close()
 
@@ -109,11 +109,10 @@ def test_leave_endpoints_are_registered(client: object) -> None:
 
 def test_create_leave_request_rejects_invalid_date_range(client: object) -> None:
     """Verify validation rejects payload where end_date is before start_date."""
-    user_id, password = _create_user_with_hire_date(
+    user_id, email, password = _create_user_with_hire_date(
         _today_utc_date() - timedelta(days=365)
     )
     try:
-        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         payload = {
@@ -128,11 +127,10 @@ def test_create_leave_request_rejects_invalid_date_range(client: object) -> None
 
 def test_create_leave_request_rejects_unknown_user(client: object) -> None:
     """Verify create request returns 404 when user does not exist."""
-    user_id, password = _create_user_with_hire_date(
+    user_id, email, password = _create_user_with_hire_date(
         _today_utc_date() - timedelta(days=365)
     )
     try:
-        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         # Use a non-existent user ID in the endpoint path (if applicable)
@@ -149,9 +147,8 @@ def test_create_leave_request_rejects_unknown_user(client: object) -> None:
 
 def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> None:
     """Verify entitlement logic rejects a request when available balance is insufficient."""
-    user_id, password = _create_user_with_hire_date(_today_utc_date())
+    user_id, email, password = _create_user_with_hire_date(_today_utc_date())
     try:
-        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         payload = {
@@ -169,11 +166,10 @@ def test_create_leave_request_consumes_balance_for_future_requests(
     client: object,
 ) -> None:
     """Verify previously created non-rejected requests reduce remaining available balance."""
-    user_id, password = _create_user_with_hire_date(
+    user_id, email, password = _create_user_with_hire_date(
         _today_utc_date() - timedelta(days=31)
     )
     try:
-        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         first_payload = {
@@ -201,11 +197,10 @@ def test_create_leave_request_consumes_balance_for_future_requests(
 
 def test_get_leave_history_is_newest_first(client: object) -> None:
     """Verify user leave history endpoint returns leave requests ordered newest first."""
-    user_id, password = _create_user_with_hire_date(
+    user_id, email, password = _create_user_with_hire_date(
         _today_utc_date() - timedelta(days=730)
     )
     try:
-        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         first_payload = {

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -18,7 +18,7 @@ def _today_utc_date() -> date:
 def _get_auth_headers(client: object, email: str, password: str) -> dict:
     """Authenticate and return authorization headers with JWT token."""
     auth_response = client.post(
-        "/auth/login", json={"email": email, "password": password}
+        "/auth/login", json={"username": email, "password": password}
     )
     if auth_response.status_code != 200:
         raise RuntimeError(f"Authentication failed: {auth_response.text}")
@@ -40,7 +40,7 @@ def client() -> object:
 
     client = TestClient(app)
 
-    test_payload = {"email": "test@example.com", "password": "testpassword"}
+    test_payload = {"username": "test@example.com", "password": "testpassword"}
     auth_response = client.post("/auth/login", json=test_payload)
     if auth_response.status_code == 200:
         token = auth_response.json().get("access_token")
@@ -95,7 +95,7 @@ def test_leave_endpoints_are_registered(client: object) -> None:
     assert response.status_code == 200
     paths = response.json().get("paths", {})
     assert "/leave/request" in paths
-    assert "/leave/my-requests/{user_id}" in paths
+    assert "/leave/my-requests" in paths
 
 
 def test_create_leave_request_rejects_invalid_date_range(client: object) -> None:
@@ -104,11 +104,10 @@ def test_create_leave_request_rejects_invalid_date_range(client: object) -> None
         _today_utc_date() - timedelta(days=365)
     )
     try:
-        email = f"qa.user.{user_id}@example.com"  # Extract from user creation
+        email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
         payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=9)).isoformat(),
         }
@@ -127,14 +126,14 @@ def test_create_leave_request_rejects_unknown_user(client: object) -> None:
         email = f"qa.user.{user_id}@example.com"
         headers = _get_auth_headers(client, email, password)
 
+        # Use a non-existent user ID in the endpoint path (if applicable)
+        # Note: With the auth changes, the endpoint uses current_user from JWT
         payload = {
-            "user_id": 999_999_999,
             "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
         }
         response = client.post("/leave/request", json=payload, headers=headers)
-        assert response.status_code == 404
-        assert response.json().get("detail") == "User not found"
+        assert response.status_code == 201
     finally:
         _cleanup_user_data(user_id)
 
@@ -147,7 +146,6 @@ def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> N
         headers = _get_auth_headers(client, email, password)
 
         payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
         }
@@ -170,12 +168,10 @@ def test_create_leave_request_consumes_balance_for_future_requests(
         headers = _get_auth_headers(client, email, password)
 
         first_payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=20)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=20)).isoformat(),
         }
         second_payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=21)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=21)).isoformat(),
         }
@@ -204,12 +200,10 @@ def test_get_leave_history_is_newest_first(client: object) -> None:
         headers = _get_auth_headers(client, email, password)
 
         first_payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=30)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=30)).isoformat(),
         }
         second_payload = {
-            "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=40)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=41)).isoformat(),
         }
@@ -226,7 +220,7 @@ def test_get_leave_history_is_newest_first(client: object) -> None:
         assert second_response.status_code == 201
         second_id = second_response.json()["id"]
 
-        history_response = client.get(f"/leave/my-requests/{user_id}", headers=headers)
+        history_response = client.get("/leave/my-requests", headers=headers)
         assert history_response.status_code == 200
 
         requests = history_response.json()

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from datetime import date, datetime, timedelta, timezone
@@ -34,7 +35,12 @@ def _create_user_with_hire_date(hire_date: date) -> int:
     db = SessionLocal()
     try:
         unique_suffix = uuid.uuid4().hex[:8]
+        email = f"qa.user.{unique_suffix}@example.com"
+        password_hash = hashlib.sha256(f"password_{unique_suffix}".encode()).hexdigest()
+
         user = models.User(
+            email=email,
+            password_hash=password_hash,
             name=f"QA User {unique_suffix}",
             role="User",
             position="QA Engineer",

--- a/backend/tests/test_leave_management.py
+++ b/backend/tests/test_leave_management.py
@@ -15,6 +15,17 @@ def _today_utc_date() -> date:
     return datetime.now(timezone.utc).date()
 
 
+def _get_auth_headers(client: object, email: str, password: str) -> dict:
+    """Authenticate and return authorization headers with JWT token."""
+    auth_response = client.post(
+        "/auth/login", json={"email": email, "password": password}
+    )
+    if auth_response.status_code != 200:
+        raise RuntimeError(f"Authentication failed: {auth_response.text}")
+    token = auth_response.json().get("access_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
 @pytest.fixture(scope="session")
 def client() -> object:
     """Provide a TestClient for leave management integration tests."""
@@ -27,16 +38,25 @@ def client() -> object:
     from fastapi.testclient import TestClient
     from main import app
 
-    return TestClient(app)
+    client = TestClient(app)
+
+    test_payload = {"email": "test@example.com", "password": "testpassword"}
+    auth_response = client.post("/auth/login", json=test_payload)
+    if auth_response.status_code == 200:
+        token = auth_response.json().get("access_token")
+        client.headers.update({"Authorization": f"Bearer {token}"})
+
+    return client
 
 
-def _create_user_with_hire_date(hire_date: date) -> int:
-    """Create a unique user record for test scenarios and return user id."""
+def _create_user_with_hire_date(hire_date: date) -> tuple[int, str]:
+    """Create a unique user record for test scenarios and return (user_id, password)."""
     db = SessionLocal()
     try:
         unique_suffix = uuid.uuid4().hex[:8]
         email = f"qa.user.{unique_suffix}@example.com"
-        password_hash = hashlib.sha256(f"password_{unique_suffix}".encode()).hexdigest()
+        password = f"password_{unique_suffix}"
+        password_hash = hashlib.sha256(password.encode()).hexdigest()
 
         user = models.User(
             email=email,
@@ -50,7 +70,7 @@ def _create_user_with_hire_date(hire_date: date) -> int:
         db.add(user)
         db.commit()
         db.refresh(user)
-        return user.id
+        return user.id, password
     finally:
         db.close()
 
@@ -80,14 +100,19 @@ def test_leave_endpoints_are_registered(client: object) -> None:
 
 def test_create_leave_request_rejects_invalid_date_range(client: object) -> None:
     """Verify validation rejects payload where end_date is before start_date."""
-    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=365))
+    user_id, password = _create_user_with_hire_date(
+        _today_utc_date() - timedelta(days=365)
+    )
     try:
+        email = f"qa.user.{user_id}@example.com"  # Extract from user creation
+        headers = _get_auth_headers(client, email, password)
+
         payload = {
             "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=9)).isoformat(),
         }
-        response = client.post("/leave/request", json=payload)
+        response = client.post("/leave/request", json=payload, headers=headers)
         assert response.status_code == 422
     finally:
         _cleanup_user_data(user_id)
@@ -95,27 +120,38 @@ def test_create_leave_request_rejects_invalid_date_range(client: object) -> None
 
 def test_create_leave_request_rejects_unknown_user(client: object) -> None:
     """Verify create request returns 404 when user does not exist."""
-    payload = {
-        "user_id": 999_999_999,
-        "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
-        "end_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
-    }
-    response = client.post("/leave/request", json=payload)
-    assert response.status_code == 404
-    assert response.json().get("detail") == "User not found"
+    user_id, password = _create_user_with_hire_date(
+        _today_utc_date() - timedelta(days=365)
+    )
+    try:
+        email = f"qa.user.{user_id}@example.com"
+        headers = _get_auth_headers(client, email, password)
+
+        payload = {
+            "user_id": 999_999_999,
+            "start_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
+            "end_date": (_today_utc_date() + timedelta(days=10)).isoformat(),
+        }
+        response = client.post("/leave/request", json=payload, headers=headers)
+        assert response.status_code == 404
+        assert response.json().get("detail") == "User not found"
+    finally:
+        _cleanup_user_data(user_id)
 
 
 def test_create_leave_request_rejects_when_balance_exceeded(client: object) -> None:
     """Verify entitlement logic rejects a request when available balance is insufficient."""
-    # Same-month hire date means earned days = 0 under current monthly accrual rule.
-    user_id = _create_user_with_hire_date(_today_utc_date())
+    user_id, password = _create_user_with_hire_date(_today_utc_date())
     try:
+        email = f"qa.user.{user_id}@example.com"
+        headers = _get_auth_headers(client, email, password)
+
         payload = {
             "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
             "end_date": (_today_utc_date() + timedelta(days=14)).isoformat(),
         }
-        response = client.post("/leave/request", json=payload)
+        response = client.post("/leave/request", json=payload, headers=headers)
         assert response.status_code == 400
         assert "Not enough leave days" in response.json().get("detail", "")
     finally:
@@ -126,9 +162,13 @@ def test_create_leave_request_consumes_balance_for_future_requests(
     client: object,
 ) -> None:
     """Verify previously created non-rejected requests reduce remaining available balance."""
-    # One month worked => 1.5 earned days, so only one 1-day request should succeed.
-    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=31))
+    user_id, password = _create_user_with_hire_date(
+        _today_utc_date() - timedelta(days=31)
+    )
     try:
+        email = f"qa.user.{user_id}@example.com"
+        headers = _get_auth_headers(client, email, password)
+
         first_payload = {
             "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=20)).isoformat(),
@@ -140,10 +180,14 @@ def test_create_leave_request_consumes_balance_for_future_requests(
             "end_date": (_today_utc_date() + timedelta(days=21)).isoformat(),
         }
 
-        first_response = client.post("/leave/request", json=first_payload)
+        first_response = client.post(
+            "/leave/request", json=first_payload, headers=headers
+        )
         assert first_response.status_code == 201
 
-        second_response = client.post("/leave/request", json=second_payload)
+        second_response = client.post(
+            "/leave/request", json=second_payload, headers=headers
+        )
         assert second_response.status_code == 400
         assert "Not enough leave days" in second_response.json().get("detail", "")
     finally:
@@ -152,8 +196,13 @@ def test_create_leave_request_consumes_balance_for_future_requests(
 
 def test_get_leave_history_is_newest_first(client: object) -> None:
     """Verify user leave history endpoint returns leave requests ordered newest first."""
-    user_id = _create_user_with_hire_date(_today_utc_date() - timedelta(days=730))
+    user_id, password = _create_user_with_hire_date(
+        _today_utc_date() - timedelta(days=730)
+    )
     try:
+        email = f"qa.user.{user_id}@example.com"
+        headers = _get_auth_headers(client, email, password)
+
         first_payload = {
             "user_id": user_id,
             "start_date": (_today_utc_date() + timedelta(days=30)).isoformat(),
@@ -165,15 +214,19 @@ def test_get_leave_history_is_newest_first(client: object) -> None:
             "end_date": (_today_utc_date() + timedelta(days=41)).isoformat(),
         }
 
-        first_response = client.post("/leave/request", json=first_payload)
+        first_response = client.post(
+            "/leave/request", json=first_payload, headers=headers
+        )
         assert first_response.status_code == 201
         first_id = first_response.json()["id"]
 
-        second_response = client.post("/leave/request", json=second_payload)
+        second_response = client.post(
+            "/leave/request", json=second_payload, headers=headers
+        )
         assert second_response.status_code == 201
         second_id = second_response.json()["id"]
 
-        history_response = client.get(f"/leave/my-requests/{user_id}")
+        history_response = client.get(f"/leave/my-requests/{user_id}", headers=headers)
         assert history_response.status_code == 200
 
         requests = history_response.json()


### PR DESCRIPTION
Resolves: #32

## 🎯 Objective
This PR implements the complete backend authentication, authorization (RBAC), and manager approval flow for the Leave Management System, transitioning the API from open access to a secure, JWT-based architecture.

## ✨ Key Features & Changes
* **Authentication:** Added `/auth/register`, `/auth/login` (JWT generation), and `/auth/me`.
* **Security:** Passwords are now securely hashed using `bcrypt`. All leave endpoints now extract user identity directly from the JWT payload.
* **RBAC (Role-Based Access Control):** Implemented a `require_manager` guard. Regular users can only see and request their own leaves, while Managers can view and process company-wide pending requests.
* **Manager Flow:** Added endpoints for managers to approve or reject (with an optional reason) leave requests.
* **Business Logic:** Added backend validation to prevent users from submitting overlapping leave requests.
* **Database Updates:** Added `email` and `password_hash` to `users`, and audit fields (`reviewed_by`, `reviewed_at`, `rejection_reason`) to `leave_requests`.

## 🛠️ Testing & Setup
* Run `python reset_db.py` to upgrade your local database schema and seed the default test accounts:
  * **User:** `ion@example.com` / `password123`
  * **Manager:** `maria@example.com` / `password123`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User registration & login with token-based auth; current-user profile endpoint
  * Manager portal to list, approve, or reject leave requests with optional rejection feedback
  * Seeded test accounts printed with emails and default password

* **Bug Fixes**
  * Leave creation and "my requests" now require authentication
  * Duplicate/overlapping leave requests are rejected to prevent conflicts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->